### PR TITLE
fix: 502 bad `gateway` error

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,9 +6,16 @@
     "build": "deno run -A --unstable dev.ts build",
     "preview": "deno run --env -A --unstable main.ts"
   },
-  "lint": { "rules": { "tags": ["fresh", "recommended"] } },
+  "lint": {
+    "rules": {
+      "tags": [
+        "fresh",
+        "recommended"
+      ]
+    }
+  },
   "imports": {
-    "$fresh/": "https://deno.land/x/fresh@1.6.0/",
+    "$fresh/": "https://deno.land/x/fresh@1.6.1/",
     "preact": "https://esm.sh/preact@10.15.1",
     "preact/": "https://esm.sh/preact@10.15.1/",
     "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.1",
@@ -21,11 +28,24 @@
     "ga4/": "https://raw.githubusercontent.com/Jabolol/ga4/main/",
     "std/": "https://deno.land/std@0.197.0/",
     "charts/": "https://deno.land/x/fresh_charts@0.3.1/",
-    "tailwindcss": "npm:tailwindcss@3.3.6",
-    "tailwindcss/": "npm:/tailwindcss@3.3.6/",
-    "tailwindcss/plugin": "npm:tailwindcss@3.3.6/plugin.js",
+    "tailwindcss": "npm:tailwindcss@3.4.1",
+    "tailwindcss/": "npm:/tailwindcss@3.4.1/",
+    "tailwindcss/plugin": "npm:tailwindcss@3.4.1/plugin.js",
     "~/": "./"
   },
-  "compilerOptions": { "jsx": "react-jsx", "jsxImportSource": "preact" },
-  "exclude": ["**/_fresh/*"]
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact"
+  },
+  "exclude": [
+    "**/_fresh/*"
+  ],
+  "deploy": {
+    "project": "9ab14b2a-b0d9-4e55-83ec-7f25f7ad1d52",
+    "exclude": [
+      "**/node_modules"
+    ],
+    "include": [],
+    "entrypoint": "main.ts"
+  }
 }


### PR DESCRIPTION
# Summary

This pull request fixes the 502 bad `gateway` error that occurs on Deno Deploy. 

<img width="570" alt="image" src="https://github.com/Jabolol/raven/assets/74559859/95deb42a-b2e8-425b-a1e5-e02864fff423">

# Reason

This error was caused by a now unsupported tailwind plugin. Solution was to migrate to `fresh@1.6.1`.

<img width="942" alt="image" src="https://github.com/Jabolol/raven/assets/74559859/1a17016e-4c31-43cc-9047-e74a7f42dfd0">
