### PR TITLE
hotifx: add missing required headers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,18 +6,11 @@
     "build": "deno run -A --unstable dev.ts build",
     "preview": "deno run --env -A --unstable main.ts"
   },
-  "lint": {
-    "rules": {
-      "tags": [
-        "fresh",
-        "recommended"
-      ]
-    }
-  },
+  "lint": { "rules": { "tags": ["fresh", "recommended"] } },
   "imports": {
-    "$fresh/": "https://deno.land/x/fresh@1.6.1/",
-    "preact": "https://esm.sh/preact@10.15.1",
-    "preact/": "https://esm.sh/preact@10.15.1/",
+    "$fresh/": "https://deno.land/x/fresh@1.6.3/",
+    "preact": "https://esm.sh/preact@10.19.2",
+    "preact/": "https://esm.sh/preact@10.19.2/",
     "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.1",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.2.3",
@@ -33,18 +26,11 @@
     "tailwindcss/plugin": "npm:tailwindcss@3.4.1/plugin.js",
     "~/": "./"
   },
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "jsxImportSource": "preact"
-  },
-  "exclude": [
-    "**/_fresh/*"
-  ],
+  "compilerOptions": { "jsx": "react-jsx", "jsxImportSource": "preact" },
+  "exclude": ["**/_fresh/*"],
   "deploy": {
     "project": "9ab14b2a-b0d9-4e55-83ec-7f25f7ad1d52",
-    "exclude": [
-      "**/node_modules"
-    ],
+    "exclude": ["**/node_modules"],
     "include": [],
     "entrypoint": "main.ts"
   }

--- a/routes/api/add.ts
+++ b/routes/api/add.ts
@@ -22,6 +22,9 @@ export const handler = async (
     {
       headers: {
         authorization: `Bearer ${access_token}`,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
       },
       method: "POST",
       body: JSON.stringify({

--- a/routes/api/changelog.ts
+++ b/routes/api/changelog.ts
@@ -49,9 +49,13 @@ export const handler = async (
     if (!deploymentRequest.ok) {
       kv.close();
       return new Response(
-        JSON.stringify({
-          error: await deploymentRequest.json(),
-        }, null, 2),
+        JSON.stringify(
+          {
+            error: await deploymentRequest.json(),
+          },
+          null,
+          2,
+        ),
         { status: 500 },
       );
     }
@@ -98,9 +102,13 @@ export const handler = async (
   if (!commitsRequest.ok) {
     kv.close();
     return new Response(
-      JSON.stringify({
-        error: await commitsRequest.json(),
-      }, null, 2),
+      JSON.stringify(
+        {
+          error: await commitsRequest.json(),
+        },
+        null,
+        2,
+      ),
       { status: 500 },
     );
   }

--- a/routes/api/discovery.ts
+++ b/routes/api/discovery.ts
@@ -21,6 +21,9 @@ export const handler = async (
     {
       headers: {
         authorization: `Bearer ${access_token}`,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
       },
     },
   );

--- a/routes/api/feed.ts
+++ b/routes/api/feed.ts
@@ -21,6 +21,9 @@ export const handler = async (
     {
       headers: {
         authorization: `Bearer ${access_token}`,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
       },
     },
   );

--- a/routes/api/friends.ts
+++ b/routes/api/friends.ts
@@ -21,6 +21,9 @@ export const handler = async (
     {
       headers: {
         authorization: `Bearer ${access_token}`,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
       },
     },
   );

--- a/routes/api/me.ts
+++ b/routes/api/me.ts
@@ -21,6 +21,9 @@ export const handler = async (
     {
       headers: {
         authorization: `Bearer ${access_token}`,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
       },
     },
   );

--- a/routes/api/react.ts
+++ b/routes/api/react.ts
@@ -24,6 +24,9 @@ export const handler = async (
     {
       headers: {
         authorization: `Bearer ${access_token}`,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
       },
       method: "POST",
       body: JSON.stringify({

--- a/routes/api/reactAll.ts
+++ b/routes/api/reactAll.ts
@@ -24,6 +24,9 @@ export const handler = async (
     {
       headers: {
         authorization: `Bearer ${access_token}`,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
       },
     },
   );
@@ -55,6 +58,9 @@ export const handler = async (
         {
           headers: {
             authorization: `Bearer ${access_token}`,
+            "bereal-app-version-code": "14549",
+            "bereal-signature": "berealsignature",
+            "bereal-device-id": "berealdeviceid",
             "content-type": "application/json",
             "accept": "application/json",
           },

--- a/routes/api/refresh.ts
+++ b/routes/api/refresh.ts
@@ -16,7 +16,7 @@ export const handler = async (
     return new Response(null, { status: 400 });
   }
 
-   const refreshResponse = await fetch(
+  const refreshResponse = await fetch(
     "https://auth.bereal.team/token?grant_type=refresh_token",
     {
       method: "POST",

--- a/routes/api/user.ts
+++ b/routes/api/user.ts
@@ -22,6 +22,9 @@ export const handler = async (
     {
       headers: {
         authorization: `Bearer ${access_token}`,
+        "bereal-app-version-code": "14549",
+        "bereal-signature": "berealsignature",
+        "bereal-device-id": "berealdeviceid",
       },
     },
   );


### PR DESCRIPTION
This PR closes #7 by adding the headers `bereal-app-version-code`, `bereal-signature` and `bereal-device-id`, that are now mandatory, to all requests. A rewrite of the `API` is on progress, with better errors, more descriptive messages and strict validation with `zod`.