### PR TITLE
hotfix: broken `refresh_token` flow

### DIFF
--- a/islands/Search.tsx
+++ b/islands/Search.tsx
@@ -21,7 +21,7 @@ export default function Search() {
 
   return (
     <div className="h-[70vh]">
-      <div className="mx-auto max-w-sm my-4 p-4 dark:bg-gray-800 border-2 border-gray-800 dark:border-white rounded-md opacity-50">
+      <div className="mx-6 max-w-sm my-4 p-4 dark:bg-gray-800 border-2 border-gray-800 dark:border-white rounded-md opacity-50">
         <input
           type="text"
           disabled

--- a/routes/api/execute.ts
+++ b/routes/api/execute.ts
@@ -26,7 +26,7 @@ export const handler = async (
   const { key, data } = await req.json();
   const [, token] = req.headers.get("authorization")!.split(" ");
   const result = await perform(key, data, token);
-  return new Response(result.error ? result.error : JSON.stringify(result), {
+  return new Response(JSON.stringify(result), {
     headers: { "content-type": "application/json" },
     status: result.error ? 400 : 200,
   });

--- a/types.ts
+++ b/types.ts
@@ -509,7 +509,7 @@ export type SelfPost = NonNullable<FeedResp["userPosts"]>["posts"][number];
 
 type MaybePromise<T> = T | Promise<T>;
 
-type Out<T> = { data: T } | { error: string };
+type Out<T> = { data: T } | { error: unknown };
 
 type Pair<T, K> = {
   in: T;


### PR DESCRIPTION
This PR closes #10 by updating the `refresh_token` url, since it got obsolete and was not a valid url anymore. Contains minor tweaks such as correcting `json` error response being invalid and adding extra `padding` to search input component.