### PR TITLE
hotfix: update `bereal` headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ BEREAL_SIGNATURE=
 
 # BeReal Device ID
 BEREAL_DEVICE_ID=
+
+# BeReal Timezone
+BEREAL_TIMEZONE=
 ```
 
 > [!WARNING]\

--- a/README.md
+++ b/README.md
@@ -60,7 +60,19 @@ Create and fill in the `.env` file:
 GITHUB_TOKEN=
 # Google Analytics tracking ID (Optional)
 GA4_MEASUREMENT_ID=
+
+# BeReal Signature
+BEREAL_SIGNATURE=
+
+# BeReal Device ID
+BEREAL_DEVICE_ID=
 ```
+
+> [!WARNING]\
+> The `BEREAL_SIGNATURE` and `BEREAL_DEVICE_ID` are required for the app to
+> function. You can find them by inspecting the network requests made by the
+> BeReal app in a rooted Android device using
+> [Burp Suite](https://portswigger.net/burp) and [Frida](https://frida.re/).
 
 Run the development server:
 

--- a/client.ts
+++ b/client.ts
@@ -8,7 +8,7 @@ export const headers = (_templates: TemplateStringsArray, token: string) => ({
   "Bereal-App-Version": "1.19.6",
   "Bereal-Os-Version": "10",
   "Bereal-Device-Id": Deno.env.get("BEREAL_DEVICE_ID")!,
-  "Bereal-Timezone": "Europe/Paris",
+  "Bereal-Timezone": Deno.env.get("BEREAL_TIMEZONE")!,
   "Bereal-App-Version-Code": "1631",
   "Bereal-Signature": Deno.env.get("BEREAL_SIGNATURE")!,
   "User-Agent": "okhttp/4.12.0",

--- a/client.ts
+++ b/client.ts
@@ -7,13 +7,12 @@ export const headers = (_templates: TemplateStringsArray, token: string) => ({
   "Bereal-Device-Language": "en-US",
   "Bereal-App-Version": "1.19.6",
   "Bereal-Os-Version": "10",
-  "Bereal-Device-Id": "7ee4e0f891cca704",
-  "Bereal-Timezone": "Europe/Madrid",
+  "Bereal-Device-Id": Deno.env.get("BEREAL_DEVICE_ID")!,
+  "Bereal-Timezone": "Europe/Paris",
   "Bereal-App-Version-Code": "1631",
-  "Bereal-Signature":
-    "MToxNzA2MDMzNzU0ODg2Oup7dtgGFyaMYEr29QlXEJt44RxF6dBBpN+PpYPz+7Zn",
-  "Authorization": `Bearer ${token}`,
+  "Bereal-Signature": Deno.env.get("BEREAL_SIGNATURE")!,
   "User-Agent": "okhttp/4.12.0",
+  "Authorization": `Bearer ${token}`,
 });
 
 const refresh = () => ({


### PR DESCRIPTION
This PR closes #12 and #13 by refreshing the expired headers `Bereal-Signature` and `Bereal-Device-Id`. Additionally, it adjusts `Bereal-Timezone` to prevent API errors caused by timezone discrepancies during signature creation.

It also makes `BEREAL_SIGNATURE`,`BEREAL_DEVICE_ID` and `BEREAL_TIMEZONE` env variables. This removes hard-coded variables from the code, easing self-hosting.