### PR TITLE
hotfix: update `auth`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,22 +61,7 @@ GITHUB_TOKEN=
 
 # Google Analytics tracking ID (Optional)
 GA4_MEASUREMENT_ID=
-
-# BeReal Signature
-BEREAL_SIGNATURE=
-
-# BeReal Device ID
-BEREAL_DEVICE_ID=
-
-# BeReal Timezone
-BEREAL_TIMEZONE=
 ```
-
-> [!WARNING]\
-> The `BEREAL_SIGNATURE` and `BEREAL_DEVICE_ID` are required for the app to
-> function. You can find them by inspecting the network requests made by the
-> BeReal app in a rooted Android device using
-> [Burp Suite](https://portswigger.net/burp) and [Frida](https://frida.re/).
 
 Run the development server:
 

--- a/client.ts
+++ b/client.ts
@@ -1,18 +1,10 @@
 import { z } from "zod";
+import getHeaders from "happy-headers";
 import { type ApiFunction, type APIMap, type ApiValidators } from "~/types.ts";
 
 export const headers = (_templates: TemplateStringsArray, token: string) => ({
-  "Bereal-Platform": "android",
-  "Bereal-App-Language": "en-US",
-  "Bereal-Device-Language": "en-US",
-  "Bereal-App-Version": "1.19.6",
-  "Bereal-Os-Version": "10",
-  "Bereal-Device-Id": Deno.env.get("BEREAL_DEVICE_ID")!,
-  "Bereal-Timezone": Deno.env.get("BEREAL_TIMEZONE")!,
-  "Bereal-App-Version-Code": "1631",
-  "Bereal-Signature": Deno.env.get("BEREAL_SIGNATURE")!,
-  "User-Agent": "okhttp/4.12.0",
   "Authorization": `Bearer ${token}`,
+  ...getHeaders(),
 });
 
 const refresh = () => ({

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
   },
   "lint": { "rules": { "tags": ["fresh", "recommended"] } },
   "imports": {
-    "$fresh/": "https://deno.land/x/fresh@1.6.5/",
+    "$fresh/": "https://deno.land/x/fresh@1.6.8/",
     "preact": "https://esm.sh/preact@10.19.2",
     "preact/": "https://esm.sh/preact@10.19.2/",
     "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.1",
@@ -28,7 +28,8 @@
     "~/": "./",
     "@twind/core": "https://esm.sh/@twind/core@1.1.3",
     "@twind/preset-tailwind": "https://esm.sh/@twind/preset-tailwind@1.1.4/",
-    "@twind/preset-autoprefix": "https://esm.sh/@twind/preset-autoprefix@1.0.7/"
+    "@twind/preset-autoprefix": "https://esm.sh/@twind/preset-autoprefix@1.0.7/",
+    "happy-headers": "npm:happy-headers"
   },
   "compilerOptions": { "jsx": "react-jsx", "jsxImportSource": "preact" },
   "exclude": ["**/_fresh/*"],

--- a/islands/Changelog.tsx
+++ b/islands/Changelog.tsx
@@ -20,7 +20,7 @@ export default function Changelog() {
 
   return (
     <div className="max-w-[50%] flex items-center flex-col">
-      <div className="bg-red-500 mt-10">
+      <div className="mt-10">
         <h1 className="text-2xl font-semibold text-center dark:text-white">
           Changelog
         </h1>

--- a/islands/Changelog.tsx
+++ b/islands/Changelog.tsx
@@ -19,8 +19,8 @@ export default function Changelog() {
   }, []);
 
   return (
-    <>
-      <div className="w-90vw mt-10">
+    <div className="max-w-[50%] flex items-center flex-col">
+      <div className="bg-red-500 mt-10">
         <h1 className="text-2xl font-semibold text-center dark:text-white">
           Changelog
         </h1>
@@ -64,6 +64,6 @@ export default function Changelog() {
           </div>
         </>
       )}
-    </>
+    </div>
   );
 }

--- a/islands/Navbar.tsx
+++ b/islands/Navbar.tsx
@@ -7,7 +7,6 @@ import IconReload from "icons/reload.tsx";
 import IconArrowBigLeft from "icons/arrow-big-left.tsx";
 import IconUser from "icons/user.tsx";
 import IconChartBar from "icons/chart-bar.tsx";
-import IconSearch from "icons/search.tsx";
 import { isLoggedIn, logout, store } from "~/state/auth.ts";
 
 export default function Navbar() {
@@ -51,11 +50,6 @@ export default function Navbar() {
           {isLogged && (
             <a href="/stats">
               <IconChartBar className="w-6 h-6 rounded-full cursor-pointer" />
-            </a>
-          )}
-          {isLogged && (
-            <a href="/search">
-              <IconSearch className="w-6 h-6 rounded-full cursor-pointer" />
             </a>
           )}
           {isDarkMode

--- a/routes/api/send.ts
+++ b/routes/api/send.ts
@@ -63,7 +63,7 @@ export const handler = async (
   }
 
   const receiptResponse = await fetch(
-    "https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyClient?key=AIzaSyDwjfEeparokD7sXPVQli9NsTuhT6fJ6iA",
+    "https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyClient?key=AIzaSyCgNTZt6gzPMh-2voYXOvrt_UR_gpGl83Q",
     {
       method: "POST",
       headers: {
@@ -103,7 +103,7 @@ export const handler = async (
   };
 
   const otpResponse = await fetch(
-    "https://www.googleapis.com/identitytoolkit/v3/relyingparty/sendVerificationCode?key=AIzaSyDwjfEeparokD7sXPVQli9NsTuhT6fJ6iA",
+    "https://www.googleapis.com/identitytoolkit/v3/relyingparty/sendVerificationCode?key=AIzaSyCgNTZt6gzPMh-2voYXOvrt_UR_gpGl83Q",
     {
       method: "POST",
       headers: {

--- a/routes/api/verify.ts
+++ b/routes/api/verify.ts
@@ -63,7 +63,7 @@ export const handler = async (
     };
 
     const googleResponse = await fetch(
-      "https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyCustomToken?key=AIzaSyDwjfEeparokD7sXPVQli9NsTuhT6fJ6iA",
+      "https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyCustomToken?key=AIzaSyCgNTZt6gzPMh-2voYXOvrt_UR_gpGl83Q",
       {
         method: "POST",
         body: JSON.stringify({
@@ -113,7 +113,7 @@ export const handler = async (
   }
 
   const fireResponse = await fetch(
-    "https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyPhoneNumber?key=AIzaSyDwjfEeparokD7sXPVQli9NsTuhT6fJ6iA",
+    "https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyPhoneNumber?key=AIzaSyCgNTZt6gzPMh-2voYXOvrt_UR_gpGl83Q",
     {
       method: "POST",
       headers: {
@@ -165,7 +165,7 @@ export const handler = async (
   }
 
   const tokenResponse = await fetch(
-    "https://securetoken.googleapis.com/v1/token?key=AIzaSyDwjfEeparokD7sXPVQli9NsTuhT6fJ6iA",
+    "https://securetoken.googleapis.com/v1/token?key=AIzaSyCgNTZt6gzPMh-2voYXOvrt_UR_gpGl83Q",
     {
       method: "POST",
       headers: {


### PR DESCRIPTION
This PR fixes #16 by using the `happy-headers` npm module for the authorisation headers. It also updates the Google API keys for `OTP` verification.